### PR TITLE
Fixed deploy config

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,3 +26,4 @@ jobs:
           deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
           publish_branch: main
           publish_dir: ./build  
+          exclude_assets: 'README.md'


### PR DESCRIPTION
Manually excluding "README.md" in the hopes that this will allow me to actually deploy the site without it defaulting to showing the readme page only when deploying on "main" branch. #reallydumbbug